### PR TITLE
[Role A] feat - 좌표변환/블러 셰이더/CPU 감지/패닉 버튼 (#10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,9 +100,32 @@ if(WIN32)
     PRIVATE
       src/window_tracker.cpp      # Role A: 블랙리스트 앱 좌표 스캐너
       src/window_tracker.h
+      src/win_event_listener.cpp  # Role A: SetWinEventHook push 감지
+      src/win_event_listener.h
   )
 endif()
 
 # OBS 표준 매크로: 출력 파일명을 "${_name}.dll" 로 강제, install 타겟 자동 생성.
 # (CMake 기본은 lib 접두사가 붙는데 OBS는 그걸 안 좋아함)
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})
+
+# 빌드 후 OBS 플러그인 경로에 자동 배포.
+# CMAKE_INSTALL_PREFIX = C:/ProgramData/obs-studio/plugins (defaults.cmake에서 설정)
+if(WIN32)
+  add_custom_command(
+    TARGET ${CMAKE_PROJECT_NAME}
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E make_directory
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/bin/64bit"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+      "$<TARGET_FILE:${CMAKE_PROJECT_NAME}>"
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/bin/64bit/"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/data"
+    COMMAND "${CMAKE_COMMAND}" -E copy_directory
+      "${CMAKE_CURRENT_SOURCE_DIR}/data"
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}/data"
+    COMMENT "Deploy ${CMAKE_PROJECT_NAME} to OBS plugins: ${CMAKE_INSTALL_PREFIX}"
+    VERBATIM
+  )
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,7 @@
       "name": "template",
       "hidden": true,
       "cacheVariables": {
-        "ENABLE_FRONTEND_API": true, // 패닉 버튼 단축키 및 obs_hotkey_register_source 호출
+        "ENABLE_FRONTEND_API": true,
         "ENABLE_QT": false
       }
     },

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -2,3 +2,4 @@
 # 가 이 파일을 자동 로드한다. 각 키는 obs_module_text("키") 호출로 번역된 문자열을 얻을 수 있다.
 # 추가 언어 지원 시 같은 폴더에 ko-KR.ini 등을 만들고 동일 키 구조로 번역값만 채우면 된다.
 SecureCastFilter="SecureCast Privacy Masking"
+PanicButton="SecureCast: Toggle Panic Mode"

--- a/data/securecast_blur.effect
+++ b/data/securecast_blur.effect
@@ -1,0 +1,90 @@
+// =============================================================================
+// securecast_blur.effect — SecureCast 마스킹 셰이더 (P2)
+//
+// 역할:
+//   영상 텍스처(image) 의 특정 박스 영역(box_offset + box_size) 을 주변
+//   픽셀과 평균낸 Gaussian Blur 로 덮어 그린다. 검정 솔리드 박스보다
+//   가장자리가 자연스러워, 박스가 카톡 본체를 1~2 px 못 cover 해도 시각적
+//   노출이 거의 인지되지 않음 (방송 표준 모자이크 효과).
+//
+// 사용:
+//   sprite 를 박스 위치 (gs_matrix_translate3f + box w/h) 로 그리면 sprite
+//   uv (0~1) 가 박스 내부 상대 좌표가 됨. fragment 에서 box_offset / box_size
+//   / image_size 로 원본 image 의 sample 좌표를 계산.
+//
+// Technique:
+//   Blur     : 5x5 box average (BlurRect.type == 0)
+//   Blackout : 단색 검정       (BlurRect.type == 1)
+// =============================================================================
+
+uniform float4x4 ViewProj;
+uniform texture2d image;
+uniform float2 box_offset;     // 박스 좌상단의 image 내부 픽셀 좌표
+uniform float2 box_size;       // 박스 크기 (픽셀)
+uniform float2 image_size;     // 영상 텍스처 크기 (픽셀)
+uniform float  blur_radius;    // blur kernel 반경 배수 (1.0 = 1 텍셀)
+
+sampler_state def_sampler {
+    Filter   = Linear;
+    AddressU = Clamp;
+    AddressV = Clamp;
+};
+
+struct VertInOut {
+    float4 pos : POSITION;
+    float2 uv  : TEXCOORD0;
+};
+
+VertInOut VSDefault(VertInOut vert_in)
+{
+    VertInOut vert_out;
+    vert_out.pos = mul(float4(vert_in.pos.xyz, 1.0), ViewProj);
+    vert_out.uv  = vert_in.uv;
+    return vert_out;
+}
+
+// 5x5 = 25-tap box average. radius 가 클수록 더 멀리서 sampling → 더 흐려짐.
+// linear sampler + clamp 라 가장자리에서 텍스처 밖을 읽어도 안전.
+float4 PSBlur(VertInOut vert_in) : TARGET
+{
+    float2 sample_pixel = box_offset + vert_in.uv * box_size;
+    float2 sample_uv    = sample_pixel / image_size;
+    float2 texel        = float2(1.0, 1.0) / image_size;
+
+    float4 color = float4(0.0, 0.0, 0.0, 0.0);
+
+    [unroll]
+    for (int dy = -2; dy <= 2; ++dy) {
+        [unroll]
+        for (int dx = -2; dx <= 2; ++dx) {
+            float2 offset = float2(dx, dy) * texel * blur_radius;
+            color += image.Sample(def_sampler, sample_uv + offset);
+        }
+    }
+    color /= 25.0;
+    color.a = 1.0;
+    return color;
+}
+
+float4 PSBlackout(VertInOut vert_in) : TARGET
+{
+    return float4(0.0, 0.0, 0.0, 1.0);
+}
+
+technique Blur
+{
+    pass
+    {
+        vertex_shader = VSDefault(vert_in);
+        pixel_shader  = PSBlur(vert_in);
+    }
+}
+
+technique Blackout
+{
+    pass
+    {
+        vertex_shader = VSDefault(vert_in);
+        pixel_shader  = PSBlackout(vert_in);
+    }
+}

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -609,6 +609,13 @@ static void securecast_video_tick(void* data, float seconds)
                     // captureWindowList에도 즉시 반영: 이번 render pushFrame 스냅샷에 포함
                     if (filter->captureWindowList.count < SC_MAX_TRACKED_WINDOWS)
                         filter->captureWindowList.items[filter->captureWindowList.count++] = tw;
+                    // Quick restore 성공: 즉시 강제 스캔을 하지 않는다.
+                    // EVENT 직후 EnumWindows의 z-order 체크(is_window_top_at_center)는
+                    // 창이 방금 포그라운드가 되어 z-order가 아직 안 정착한 상태라
+                    // 일시적으로 실패할 수 있다. 실패하면 scan 결과가 {}가 되어
+                    // windowList와 captureWindowList를 덮어쓰고 방금 복원한 항목이 사라진다.
+                    // 대신 다음 render의 sc_update_tracked_bounds가 안정적으로 확인하게 맡긴다.
+                    filter->trackerAccumulator = 0.0f;
                 }
                 break;
             }

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -585,9 +585,57 @@ static void securecast_video_tick(void* data, float seconds)
         return;
 
 #ifdef _WIN32
-    if (filter->winListener.checkAndClearRescan())
+    if (filter->winListener.checkAndClearRescan()) {
         filter->trackerAccumulator = SCAN_INTERVAL_FORCE;
+
+        // Quick restore: foreground 전환 이벤트 직후 recentlySeenList 조회 → 즉시 복원.
+        // EnumWindows 스캔(느림) 전에 captureWindowList를 채워
+        // 이번 render의 pushFrame 시점부터 마스킹이 적용되도록 한다.
+        HWND fgHwnd = GetForegroundWindow();
+        if (fgHwnd) {
+            for (int ri = 0; ri < filter->recentlySeenList.count; ++ri) {
+                if (filter->recentlySeenList.items[ri].hwnd != fgHwnd)
+                    continue;
+                bool alreadyTracked = false;
+                for (int wi = 0; wi < filter->windowList.count; ++wi) {
+                    if (filter->windowList.items[wi].hwnd == fgHwnd) {
+                        alreadyTracked = true;
+                        break;
+                    }
+                }
+                if (!alreadyTracked && filter->windowList.count < SC_MAX_TRACKED_WINDOWS) {
+                    const TrackedWindow& tw = filter->recentlySeenList.items[ri];
+                    filter->windowList.items[filter->windowList.count++] = tw;
+                    // captureWindowList에도 즉시 반영: 이번 render pushFrame 스냅샷에 포함
+                    if (filter->captureWindowList.count < SC_MAX_TRACKED_WINDOWS)
+                        filter->captureWindowList.items[filter->captureWindowList.count++] = tw;
+                }
+                break;
+            }
+        }
+    }
     sc_tracker_tick(seconds, &filter->trackerAccumulator, &filter->windowList);
+
+    // recentlySeenList 유지: windowList 항목을 upsert, 완전히 닫힌 HWND 제거.
+    // recentlySeenList는 앱이 다시 등장했을 때 quick restore의 소스가 된다.
+    for (int wi = 0; wi < filter->windowList.count; ++wi) {
+        HWND wh = filter->windowList.items[wi].hwnd;
+        bool found = false;
+        for (int ri = 0; ri < filter->recentlySeenList.count; ++ri) {
+            if (filter->recentlySeenList.items[ri].hwnd == wh) {
+                filter->recentlySeenList.items[ri] = filter->windowList.items[wi];
+                found = true;
+                break;
+            }
+        }
+        if (!found && filter->recentlySeenList.count < SC_MAX_TRACKED_WINDOWS)
+            filter->recentlySeenList.items[filter->recentlySeenList.count++] = filter->windowList.items[wi];
+    }
+    // 완전히 닫힌 프로세스의 HWND 정리 (최소화/숨김은 IsWindow=true라 유지됨)
+    for (int ri = filter->recentlySeenList.count - 1; ri >= 0; --ri) {
+        if (!IsWindow(filter->recentlySeenList.items[ri].hwnd))
+            filter->recentlySeenList.items[ri] = filter->recentlySeenList.items[--filter->recentlySeenList.count];
+    }
 
     // Lingering: 직전 스캔에 있었지만 이번엔 사라진 창 감지.
     // windowList는 slow-scan 주기(150ms)마다만 바뀌므로 비교는 실질적으로 그때만 의미 있다.

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-// window_tracker.cpp의 SCAN_INTERVAL_SEC(0.15f) 이상이면 즉시 스캔 트리거.
+// trackerAccumulator에 이 값을 대입하면 다음 sc_tracker_tick 호출 시 임계를 즉시 초과 → 강제 스캔 트리거.
 static constexpr float SCAN_INTERVAL_FORCE    = 1.0f;
 static constexpr float SCAN_INTERVAL_NORMAL   = 0.15f; // 일반 모드 스캔 주기
 static constexpr float SCAN_INTERVAL_GAME     = 0.5f;  // 게임 모드 스캔 주기
@@ -165,6 +165,7 @@ static void render_blur_rect(gs_effect_t *fx, gs_texture_t *img_tex,
 // [Role C] FrameRingBuffer 구현부
 // ================================================================
 
+// GPU에 gs_texrender 슬롯을 할당한다. video_render 첫 호출 또는 해상도 변경 시 호출.
 bool FrameRingBuffer::initialize(uint32_t width, uint32_t height)
 {
     if (m_initialized)
@@ -189,6 +190,7 @@ bool FrameRingBuffer::initialize(uint32_t width, uint32_t height)
     return true;
 }
 
+// 모든 슬롯의 GPU 텍스처를 해제하고 버퍼를 초기 상태로 되돌린다. 소멸자 또는 해상도 변경 시 호출.
 void FrameRingBuffer::destroy()
 {
     if (!m_initialized)
@@ -210,6 +212,8 @@ void FrameRingBuffer::destroy()
     blog(LOG_INFO, "FrameRingBuffer destroyed.");
 }
 
+// 현재 OBS 소스 프레임을 HEAD 슬롯에 캡처하고, 창 좌표 스냅샷을 함께 저장한다.
+// HEAD를 한 칸 전진시켜 다음 pushFrame이 다음 슬롯에 쓰도록 한다.
 #ifdef _WIN32
 void FrameRingBuffer::pushFrame(obs_source_t* source, uint64_t timestamp,
                                  const TrackedWindowList* wlist)
@@ -251,11 +255,13 @@ void FrameRingBuffer::pushFrame(obs_source_t* source, uint64_t timestamp)
         m_frameCount++;
 }
 
+// N프레임(SC_RING_BUFFER_SLOTS) 전 슬롯을 반환한다. 인코더로 출력하는 "안전한" 지연 프레임.
 const FrameRingBuffer::Slot* FrameRingBuffer::peekDelayedSlot() const
 {
     return peekSlotAtOffset(SC_RING_BUFFER_SLOTS);
 }
 
+// HEAD에서 framesBack만큼 이전 슬롯을 반환한다. N-1 슬롯과의 합집합 마스킹(빠른 이동 커버)에 사용.
 const FrameRingBuffer::Slot* FrameRingBuffer::peekSlotAtOffset(int framesBack) const
 {
     if (framesBack <= 0 || m_frameCount < framesBack)
@@ -269,6 +275,7 @@ const FrameRingBuffer::Slot* FrameRingBuffer::peekSlotAtOffset(int framesBack) c
 // [Role C] MockAIWorker 구현부
 // ================================================================
 
+// 워커 스레드를 시작한다. AI 분석이 완료될 때마다 callback으로 마스킹 결과를 전달.
 void MockAIWorker::start(uint32_t frameWidth, uint32_t frameHeight, ResultCallback callback)
 {
     if (m_running.load())
@@ -284,6 +291,7 @@ void MockAIWorker::start(uint32_t frameWidth, uint32_t frameHeight, ResultCallba
             m_frameWidth, m_frameHeight);
 }
 
+// 워커 스레드에 종료 신호를 보내고 join한다. securecast_destroy() 에서 ring buffer 해제 전에 반드시 호출.
 void MockAIWorker::stop()
 {
     if (!m_running.load())
@@ -301,6 +309,7 @@ void MockAIWorker::stop()
     blog(LOG_INFO, "MockAIWorker stopped.");
 }
 
+// 게임 모드 진입/해제 시 호출. paused=true면 스레드는 cv.wait에서 대기해 CPU를 점유하지 않는다.
 void MockAIWorker::setPaused(bool paused)
 {
     if (!m_running.load())
@@ -313,6 +322,8 @@ void MockAIWorker::setPaused(bool paused)
     blog(LOG_INFO, "MockAIWorker %s.", paused ? "paused" : "resumed");
 }
 
+// 워커 스레드 본체. 50ms 주기로 빈 페이로드를 publish한다.
+// Role B 구현 시 여기서 OCR 호출 후 실제 BlurRect를 채워 publish하도록 교체.
 void MockAIWorker::workerLoop()
 {
     while (m_running.load()) {
@@ -353,6 +364,7 @@ void MockAIWorker::workerLoop()
 // m_pending 쓰기 중에 Render Thread가 읽으면 torn read가 발생한다.
 // ================================================================
 
+// AI 스레드 → Render 스레드 결과 전달. 뮤텍스로 m_pending 기록 보호 후 ready 플래그를 set.
 void AtomicMaskChannel::publish(const MaskPayload& payload)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -360,6 +372,7 @@ void AtomicMaskChannel::publish(const MaskPayload& payload)
     m_ready.store(true, std::memory_order_release);
 }
 
+// Render 스레드가 새 마스킹 결과를 꺼낸다. 새 데이터가 없으면 false 반환 (lastMask 유지).
 bool AtomicMaskChannel::consume(MaskPayload& out)
 {
     if (!m_ready.load(std::memory_order_acquire))
@@ -765,7 +778,7 @@ static void securecast_video_tick(void* data, float seconds)
                     filter->isGameMode       = false;
                     filter->gameModeExitTimer = 0.0f;
                     filter->mockWorker.setPaused(false);
-                    blog(LOG_INFO, "[SecureCast] Game mode OFF (CPU: %.0f%%, 10s cooldown)", filter->cpuUsage);
+                    blog(LOG_INFO, "[SecureCast] Game mode OFF (CPU: %.0f%%, 5s cooldown)", filter->cpuUsage);
                 }
             } else {
                 filter->gameModeExitTimer = 0.0f;
@@ -774,7 +787,7 @@ static void securecast_video_tick(void* data, float seconds)
     }
 
     // ── WinEvent: 포그라운드 전환 감지 → Quick Restore ─
-    // 게임 모드는 CPU 임계값(<30%, 10s)으로만 해제한다.
+    // 게임 모드는 CPU 임계값(≤30%, 5s)으로만 해제한다.
     // WinEvent로 해제하면 게임 실행 중 발생하는 내부 창 이벤트(알림, 팝업 등)에
     // 의해 게임 모드가 즉시 끊겼다가 3초 후 재진입하는 깜빡임이 발생한다.
     if (filter->winListener.checkAndClearRescan()) {

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -66,10 +66,10 @@ static float sampleCpuUsage(FILETIME* prevIdle, FILETIME* prevKernel, FILETIME* 
     *prevUser   = user;
 
     uint64_t total = kernelDiff + userDiff;
-    if (total == 0)
+    if (total == 0 || idleDiff > total)
         return 0.0f;
 
-    return (float)(total - idleDiff) / (float)total * 100.0f;
+    return std::clamp((float)(total - idleDiff) / (float)total * 100.0f, 0.0f, 100.0f);
 }
 #endif
 
@@ -584,6 +584,40 @@ static void securecast_video_render(void* data, gs_effect_t* effect)
         });
     }
 
+    // --- Panic Mode: pushFrame 이전에 차단 ---
+    // 패닉 중에는 링 버퍼를 파괴해 GPU 낭비를 막고,
+    // 해제 직후 패닉 중 캡처된 프레임이 스트림에 유출되는 것을 방지한다.
+    // ringBuffer.destroy()는 이미 파괴된 경우 no-op이라 매 프레임 호출해도 안전.
+    if (filter->panicMode.load(std::memory_order_relaxed)) {
+        filter->ringBuffer.destroy();
+
+        gs_effect_t* solid = obs_get_base_effect(OBS_EFFECT_SOLID);
+
+        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFF000000);
+        while (gs_effect_loop(solid, "Solid"))
+            gs_draw_sprite(nullptr, 0, w, h);
+
+        constexpr uint32_t BORDER = 6;
+        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFFFF0000);
+        while (gs_effect_loop(solid, "Solid")) {
+            gs_matrix_push(); gs_matrix_identity();
+            gs_draw_sprite(nullptr, 0, w, BORDER);
+            gs_matrix_pop();
+            gs_matrix_push(); gs_matrix_identity();
+            gs_matrix_translate3f(0.0f, (float)(h - BORDER), 0.0f);
+            gs_draw_sprite(nullptr, 0, w, BORDER);
+            gs_matrix_pop();
+            gs_matrix_push(); gs_matrix_identity();
+            gs_draw_sprite(nullptr, 0, BORDER, h);
+            gs_matrix_pop();
+            gs_matrix_push(); gs_matrix_identity();
+            gs_matrix_translate3f((float)(w - BORDER), 0.0f, 0.0f);
+            gs_draw_sprite(nullptr, 0, BORDER, h);
+            gs_matrix_pop();
+        }
+        return;
+    }
+
     // --- Step 2: 현재 프레임을 Ring Buffer HEAD에 Push ---
     // OBS 소스 내부 버퍼링으로 obs_source_video_render()가 반환하는 픽셀은
     // 실제 DWM 쿼리보다 ~1프레임 뒤처진다.
@@ -603,39 +637,6 @@ static void securecast_video_render(void* data, gs_effect_t* effect)
     MaskPayload newMask{};
     if (filter->maskChannel.consume(newMask))
         filter->lastMask = newMask;
-
-    // --- Panic Mode (Ctrl+Shift+F12) ---
-    // ring buffer는 계속 채우되 인코더로는 전체 블랙 + 빨간 테두리만 출력.
-    // 스트리머는 빨간 테두리로 패닉 활성 여부를 확인할 수 있다.
-    if (filter->panicMode.load(std::memory_order_relaxed)) {
-        gs_effect_t* solid = obs_get_base_effect(OBS_EFFECT_SOLID);
-
-        // 전체 블랙아웃
-        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFF000000);
-        while (gs_effect_loop(solid, "Solid"))
-            gs_draw_sprite(nullptr, 0, w, h);
-
-        // 빨간 테두리 6px
-        constexpr uint32_t BORDER = 6;
-        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFFFF0000);
-        while (gs_effect_loop(solid, "Solid")) {
-            gs_matrix_push(); gs_matrix_identity();
-            gs_draw_sprite(nullptr, 0, w, BORDER);                          // top
-            gs_matrix_pop();
-            gs_matrix_push(); gs_matrix_identity();
-            gs_matrix_translate3f(0.0f, (float)(h - BORDER), 0.0f);
-            gs_draw_sprite(nullptr, 0, w, BORDER);                          // bottom
-            gs_matrix_pop();
-            gs_matrix_push(); gs_matrix_identity();
-            gs_draw_sprite(nullptr, 0, BORDER, h);                          // left
-            gs_matrix_pop();
-            gs_matrix_push(); gs_matrix_identity();
-            gs_matrix_translate3f((float)(w - BORDER), 0.0f, 0.0f);
-            gs_draw_sprite(nullptr, 0, BORDER, h);                          // right
-            gs_matrix_pop();
-        }
-        return;
-    }
 
     // --- Step 4~5: N프레임 지연된 슬롯 꺼내기 ---
     const FrameRingBuffer::Slot* delayedSlot = filter->ringBuffer.peekDelayedSlot();

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -15,13 +15,107 @@
 //   securecast_video_render  : 매 프레임 (60fps), 실제 픽셀 렌더링 단계
 // =============================================================================
 
+// NOMINMAX must be defined before any Windows header to prevent min/max macro conflicts
+// with std::max / std::min from <algorithm>.
+#define NOMINMAX
 #include "securecast-filter.h"
 #include "plugin-support.h"   // obs_log
 #include "window_tracker.h"   // sc_tracker_tick (Role A: 블랙리스트 앱 좌표 수집)
+#include <algorithm>
 #include <chrono>
 #include <stdlib.h>
 #include <string.h>
-#include "securecast-filter.h"
+
+// window_tracker.cpp의 SCAN_INTERVAL_SEC(0.15f) 이상이면 즉시 스캔 트리거.
+static constexpr float SCAN_INTERVAL_FORCE = 1.0f;
+
+// ================================================================
+// [Role A] 윈도우 좌표 → OBS 소스 픽셀 좌표 변환 + 15% BBox 팽창
+//
+// TrackedWindow.bounds : DWM 화면 절대좌표 (물리 픽셀)
+// src_w / src_h        : OBS 소스 해상도 (= 캡처 모니터 해상도와 같다고 가정)
+//
+// 변환 순서:
+//   1. MonitorFromWindow → 창이 속한 모니터의 원점(rcMonitor.left/top) 파악
+//   2. 창 좌표 - 모니터 원점 → 모니터 상대 좌표
+//   3. (모니터 상대 좌표 / 모니터 크기) * 소스 크기 → 소스 픽셀 좌표
+//   4. 15% BBox 팽창 후 소스 경계로 clamp
+// ================================================================
+#ifdef _WIN32
+static BlurRect tracked_window_to_blur_rect(const TrackedWindow &tw,
+                                             uint32_t src_w, uint32_t src_h)
+{
+    BlurRect r{};
+    // MonitorFromRect을 사용해야 lingering window(이미 닫힌 hwnd)에도 동작한다.
+    HMONITOR hmon = MonitorFromRect(&tw.bounds, MONITOR_DEFAULTTONEAREST);
+    if (!hmon)
+        return r;
+
+    MONITORINFO mi{};
+    mi.cbSize = sizeof(MONITORINFO);
+    if (!GetMonitorInfo(hmon, &mi))
+        return r;
+
+    int mon_w = mi.rcMonitor.right  - mi.rcMonitor.left;
+    int mon_h = mi.rcMonitor.bottom - mi.rcMonitor.top;
+    if (mon_w <= 0 || mon_h <= 0)
+        return r;
+
+    float sx = (float)src_w / mon_w;
+    float sy = (float)src_h / mon_h;
+
+    int x  = (int)((tw.bounds.left - mi.rcMonitor.left) * sx);
+    int y  = (int)((tw.bounds.top  - mi.rcMonitor.top ) * sy);
+    int bw = (int)((tw.bounds.right  - tw.bounds.left) * sx);
+    int bh = (int)((tw.bounds.bottom - tw.bounds.top ) * sy);
+
+    // 비대칭 BBox 팽창 — 위쪽(타이틀바 위)은 최소, 좌/우/아래는 빠른 이동 여유 포함.
+    // 위: 1%  / 좌우: 5% (이동 시 trailing edge 커버) / 아래: 3%
+    int exp_top    = (int)(bh * 0.01f);
+    int exp_sides  = (int)(bw * 0.025f);
+    int exp_bottom = (int)(bh * 0.015f);
+    x  = std::max(0,          x  - exp_sides);
+    y  = std::max(0,          y  - exp_top);
+    bw = std::min((int)src_w - x, bw + exp_sides * 2);
+    bh = std::min((int)src_h - y, bh + exp_top + exp_bottom);
+
+    r = {x, y, bw, bh, 0}; // type 0 = Blur (Blackout과 시각적으로 구분 가능)
+    return r;
+}
+#endif
+
+// ================================================================
+// [Role A] blur.effect 셰이더로 BlurRect 1개를 렌더링
+//
+// type == 0 (Blur)    : image 텍스처를 box_offset/size 기준으로 5x5 평균
+// type == 1 (Blackout): 단색 검정
+// ================================================================
+static void render_blur_rect(gs_effect_t *fx, gs_texture_t *img_tex,
+                              const BlurRect &r, uint32_t src_w, uint32_t src_h)
+{
+    if (r.width <= 0 || r.height <= 0)
+        return;
+
+    const char *tech = (r.type == 0) ? "Blur" : "Blackout";
+
+    if (r.type == 0) {
+        struct vec2 box_off = {(float)r.x, (float)r.y};
+        struct vec2 box_sz  = {(float)r.width, (float)r.height};
+        struct vec2 img_sz  = {(float)src_w, (float)src_h};
+        gs_effect_set_texture(gs_effect_get_param_by_name(fx, "image"),      img_tex);
+        gs_effect_set_vec2(   gs_effect_get_param_by_name(fx, "box_offset"), &box_off);
+        gs_effect_set_vec2(   gs_effect_get_param_by_name(fx, "box_size"),   &box_sz);
+        gs_effect_set_vec2(   gs_effect_get_param_by_name(fx, "image_size"), &img_sz);
+        gs_effect_set_float(  gs_effect_get_param_by_name(fx, "blur_radius"), 8.0f);
+    }
+
+    gs_matrix_push();
+    gs_matrix_identity();
+    gs_matrix_translate3f((float)r.x, (float)r.y, 0.0f);
+    while (gs_effect_loop(fx, tech))
+        gs_draw_sprite(nullptr, 0, (uint32_t)r.width, (uint32_t)r.height);
+    gs_matrix_pop();
+}
 
 // ================================================================
 // [Role C] FrameRingBuffer 구현부
@@ -72,10 +166,22 @@ void FrameRingBuffer::destroy()
     blog(LOG_INFO, "FrameRingBuffer destroyed.");
 }
 
+#ifdef _WIN32
+void FrameRingBuffer::pushFrame(obs_source_t* source, uint64_t timestamp,
+                                 const TrackedWindowList* wlist)
+#else
 void FrameRingBuffer::pushFrame(obs_source_t* source, uint64_t timestamp)
+#endif
 {
     if (!m_initialized)
         return;
+
+#ifdef _WIN32
+    if (wlist)
+        m_slots[m_head].windowSnapshot = *wlist;
+    else
+        m_slots[m_head].windowSnapshot = TrackedWindowList{};
+#endif
 
     gs_texrender_t* tr = m_slots[m_head].texrender;
     gs_texrender_reset(tr);
@@ -103,11 +209,16 @@ void FrameRingBuffer::pushFrame(obs_source_t* source, uint64_t timestamp)
 
 const FrameRingBuffer::Slot* FrameRingBuffer::peekDelayedSlot() const
 {
-    if (m_frameCount < SC_RING_BUFFER_SLOTS)
-        return nullptr;
+    return peekSlotAtOffset(SC_RING_BUFFER_SLOTS);
+}
 
-    int tail = (m_head - SC_RING_BUFFER_SLOTS + SC_RING_BUFFER_SLOTS) % SC_RING_BUFFER_SLOTS;
-    return &m_slots[tail];
+const FrameRingBuffer::Slot* FrameRingBuffer::peekSlotAtOffset(int framesBack) const
+{
+    if (framesBack <= 0 || m_frameCount < framesBack)
+        return nullptr;
+    int idx = ((m_head - framesBack) % SC_RING_BUFFER_SLOTS + SC_RING_BUFFER_SLOTS)
+              % SC_RING_BUFFER_SLOTS;
+    return &m_slots[idx];
 }
 
 // ================================================================
@@ -159,14 +270,9 @@ void MockAIWorker::workerLoop()
         if (!m_running.load())
             break;
 
-        // 가짜 마스킹 결과 생성: 화면 정중앙에 200x100 픽셀의 블랙아웃 박스 하나
+        // Role B(실제 OCR/AI) 미구현 — 빈 페이로드 전달 (중앙 박스 제거)
         MaskPayload payload{};
-        payload.rectCount = 1;
-        payload.rects[0].x     = static_cast<int>(m_frameWidth  / 2) - 100;
-        payload.rects[0].y     = static_cast<int>(m_frameHeight / 2) - 50;
-        payload.rects[0].width  = 200;
-        payload.rects[0].height = 100;
-        payload.rects[0].type   = 1; // Blackout
+        payload.rectCount = 0;
 
         if (m_callback)
             m_callback(payload);
@@ -235,6 +341,23 @@ static void* securecast_create(obs_data_t* settings, obs_source_t* context)
     // FrameRingBuffer는 첫 video_render 호출 시 지연 초기화 (OBS gs context 필요)
     // MockAIWorker도 렌더러가 실제 해상도를 알게 되는 시점(video_render)에 맞춰 시작하도록 연기합니다.
 
+#ifdef _WIN32
+    filter->winListener.start();
+#endif
+
+    // HLSL 셰이더 컴파일 (그래픽스 컨텍스트 필요)
+    obs_enter_graphics();
+    char *effect_path = obs_module_file("securecast_blur.effect");
+    if (effect_path) {
+        filter->blurEffect = gs_effect_create_from_file(effect_path, nullptr);
+        bfree(effect_path);
+    }
+    obs_leave_graphics();
+    if (!filter->blurEffect)
+        blog(LOG_WARNING, "[SecureCast] blur effect load failed; falling back to solid blackout.");
+    else
+        blog(LOG_INFO, "[SecureCast] blur effect loaded.");
+
     blog(LOG_INFO, "Filter created (Role C: Mock Pipeline Active).");
     return filter;
 }
@@ -246,8 +369,20 @@ static void securecast_destroy(void* data)
 
     blog(LOG_INFO, "Destroying filter...");
 
+#ifdef _WIN32
+    filter->winListener.stop();
+#endif
+
     // AI 워커 먼저 중지 (콜백이 ring buffer에 접근하지 않도록)
     filter->mockWorker.stop();
+
+    // GPU 리소스 해제
+    obs_enter_graphics();
+    if (filter->blurEffect) {
+        gs_effect_destroy(filter->blurEffect);
+        filter->blurEffect = nullptr;
+    }
+    obs_leave_graphics();
 
     // GPU 텍스처 해제 (내부에서 obs_enter/leave_graphics 처리)
     filter->ringBuffer.destroy();
@@ -333,8 +468,19 @@ static void securecast_video_render(void* data, gs_effect_t* effect)
     }
 
     // --- Step 2: 현재 프레임을 Ring Buffer HEAD에 Push ---
+    // OBS 소스 내부 버퍼링으로 obs_source_video_render()가 반환하는 픽셀은
+    // 실제 DWM 쿼리보다 ~1프레임 뒤처진다.
+    // captureWindowList(직전 프레임에서 저장한 DWM 좌표)를 스냅샷으로 쓰면
+    // 픽셀 내용과 마스크 위치가 정확히 동기화된다.
     uint64_t ts = obs_get_video_frame_time();
+#ifdef _WIN32
+    filter->ringBuffer.pushFrame(parent, ts, &filter->captureWindowList);
+    // push 이후에 DWM 갱신 → 다음 프레임의 captureWindowList로 저장
+    sc_update_tracked_bounds(&filter->windowList);
+    filter->captureWindowList = filter->windowList;
+#else
     filter->ringBuffer.pushFrame(parent, ts);
+#endif
 
     // --- Step 3: AI 결과 채널에서 최신 마스킹 페이로드 Consume ---
     MaskPayload newMask{};
@@ -360,20 +506,63 @@ static void securecast_video_render(void* data, gs_effect_t* effect)
     while (gs_effect_loop(draw, "Draw"))
         gs_draw_sprite(delayedTex, 0, w, h);
 
-    // --- 마스킹 오버레이: BlurRect 영역에 검정 박스 덮어쓰기 (Mock 시각화) ---
-    // TODO (Role A): 이 부분을 HLSL Pixel Blur Shader 호출로 교체
-    if (filter->lastMask.rectCount > 0) {
-        gs_effect_t* solid = obs_get_base_effect(OBS_EFFECT_SOLID);
-        gs_eparam_t* colorParam = gs_effect_get_param_by_name(solid, "color");
-        gs_effect_set_color(colorParam, 0xFF000000); // 불투명 검정
+    // --- 마스킹 오버레이 ---
+    // Role A: delayedSlot->windowSnapshot (프레임 캡처 시점의 창 위치 → 프레임과 동기화됨)
+    // Role B/C: lastMask (AI/MockAI 결과)
+    BlurRect all_rects[SC_MAX_BLUR_RECTS + SC_MAX_TRACKED_WINDOWS];
+    int all_count = 0;
 
+#ifdef _WIN32
+    // N프레임 전 스냅샷 (현재 렌더링 중인 지연 프레임과 동기화)
+    for (int i = 0; i < delayedSlot->windowSnapshot.count &&
+                    all_count < (int)(sizeof(all_rects) / sizeof(all_rects[0])); i++) {
+        BlurRect r = tracked_window_to_blur_rect(delayedSlot->windowSnapshot.items[i], w, h);
+        if (r.width > 0 && r.height > 0)
+            all_rects[all_count++] = r;
+    }
+    // N-1프레임 전 스냅샷 합집합: 한 프레임 이동 궤적 전체를 마스킹 (빠른 드래그 노출 방지)
+    {
+        const FrameRingBuffer::Slot* slotN1 =
+            filter->ringBuffer.peekSlotAtOffset(SC_RING_BUFFER_SLOTS - 1);
+        if (slotN1) {
+            for (int i = 0; i < slotN1->windowSnapshot.count &&
+                            all_count < (int)(sizeof(all_rects) / sizeof(all_rects[0])); i++) {
+                BlurRect r = tracked_window_to_blur_rect(slotN1->windowSnapshot.items[i], w, h);
+                if (r.width > 0 && r.height > 0)
+                    all_rects[all_count++] = r;
+            }
+        }
+    }
+    // Lingering rects: 사라진 창의 N프레임 잔영 (ring buffer에 남은 과거 프레임 커버)
+    for (int li = 0; li < filter->lingeringCount &&
+                     all_count < (int)(sizeof(all_rects) / sizeof(all_rects[0])); ++li) {
+        BlurRect r = tracked_window_to_blur_rect(filter->lingeringWindows[li].window, w, h);
+        if (r.width > 0 && r.height > 0)
+            all_rects[all_count++] = r;
+    }
+#endif
+    for (int i = 0; i < filter->lastMask.rectCount &&
+                    all_count < (int)(sizeof(all_rects) / sizeof(all_rects[0])); i++)
+        all_rects[all_count++] = filter->lastMask.rects[i];
+
+    if (all_count == 0)
+        return;
+
+    if (filter->blurEffect) {
+        // blur.effect 셰이더 사용 (Blur / Blackout technique)
+        for (int i = 0; i < all_count; i++)
+            render_blur_rect(filter->blurEffect, delayedTex, all_rects[i], w, h);
+    } else {
+        // 셰이더 로드 실패 시 fallback: 단색 검정 박스
+        gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
+        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFF000000);
         gs_matrix_push();
         while (gs_effect_loop(solid, "Solid")) {
-            for (int i = 0; i < filter->lastMask.rectCount; i++) {
-                const BlurRect& r = filter->lastMask.rects[i];
+            for (int i = 0; i < all_count; i++) {
                 gs_matrix_identity();
-                gs_matrix_translate3f((float)r.x, (float)r.y, 0.0f);
-                gs_draw_sprite(nullptr, 0, (uint32_t)r.width, (uint32_t)r.height);
+                gs_matrix_translate3f((float)all_rects[i].x, (float)all_rects[i].y, 0.0f);
+                gs_draw_sprite(nullptr, 0, (uint32_t)all_rects[i].width,
+                               (uint32_t)all_rects[i].height);
             }
         }
         gs_matrix_pop();
@@ -395,7 +584,41 @@ static void securecast_video_tick(void* data, float seconds)
     if (!filter || !filter->isActive)
         return;
 
-    sc_tracker_tick(seconds, &filter->trackerAccumulator);
+#ifdef _WIN32
+    if (filter->winListener.checkAndClearRescan())
+        filter->trackerAccumulator = SCAN_INTERVAL_FORCE;
+    sc_tracker_tick(seconds, &filter->trackerAccumulator, &filter->windowList);
+
+    // Lingering: 직전 스캔에 있었지만 이번엔 사라진 창 감지.
+    // windowList는 slow-scan 주기(150ms)마다만 바뀌므로 비교는 실질적으로 그때만 의미 있다.
+    for (int pi = 0; pi < filter->prevWindowList.count; ++pi) {
+        HWND ph = filter->prevWindowList.items[pi].hwnd;
+        bool found = false;
+        for (int ci = 0; ci < filter->windowList.count && !found; ++ci)
+            found = (filter->windowList.items[ci].hwnd == ph);
+        if (!found) {
+            bool already = false;
+            for (int li = 0; li < filter->lingeringCount; ++li) {
+                if (filter->lingeringWindows[li].window.hwnd == ph) {
+                    filter->lingeringWindows[li].ticksRemaining = SC_RING_BUFFER_SLOTS;
+                    already = true;
+                    break;
+                }
+            }
+            if (!already && filter->lingeringCount < SC_MAX_LINGERING)
+                filter->lingeringWindows[filter->lingeringCount++] = {
+                    filter->prevWindowList.items[pi], SC_RING_BUFFER_SLOTS
+                };
+        }
+    }
+    filter->prevWindowList = filter->windowList;
+
+    // 매 tick 카운트다운 → 정확히 N프레임(ring buffer 지연) 후 자연 제거
+    for (int li = filter->lingeringCount - 1; li >= 0; --li) {
+        if (--filter->lingeringWindows[li].ticksRemaining <= 0)
+            filter->lingeringWindows[li] = filter->lingeringWindows[--filter->lingeringCount];
+    }
+#endif
 }
   
 // ================================================================

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -659,6 +659,33 @@ static void securecast_video_tick(void* data, float seconds)
                 };
         }
     }
+
+    // New window detection: 이번 스캔에서 새로 등장한 창을 즉시 lingering에 prime.
+    // 탐지 전에 ring buffer에 이미 쌓인 프레임(최대 SC_RING_BUFFER_SLOTS개)이
+    // 출력될 때도 마스킹되도록 SC_RING_BUFFER_SLOTS+1 틱을 부여한다.
+    // (+1: 탐지 틱의 render에서 captureWindowList가 업데이트되기 전에
+    //  pushFrame이 먼저 실행되어 생기는 1프레임 갭을 커버)
+    for (int ci = 0; ci < filter->windowList.count; ++ci) {
+        HWND ch = filter->windowList.items[ci].hwnd;
+        bool wasPrev = false;
+        for (int pi = 0; pi < filter->prevWindowList.count; ++pi) {
+            if (filter->prevWindowList.items[pi].hwnd == ch) { wasPrev = true; break; }
+        }
+        if (!wasPrev) {
+            bool already = false;
+            for (int li = 0; li < filter->lingeringCount; ++li) {
+                if (filter->lingeringWindows[li].window.hwnd == ch) {
+                    filter->lingeringWindows[li].ticksRemaining = SC_RING_BUFFER_SLOTS + 1;
+                    already = true; break;
+                }
+            }
+            if (!already && filter->lingeringCount < SC_MAX_LINGERING)
+                filter->lingeringWindows[filter->lingeringCount++] = {
+                    filter->windowList.items[ci], SC_RING_BUFFER_SLOTS + 1
+                };
+        }
+    }
+
     filter->prevWindowList = filter->windowList;
 
     // 매 tick 카운트다운 → 정확히 N프레임(ring buffer 지연) 후 자연 제거

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -21,6 +21,7 @@
 #include "securecast-filter.h"
 #include "plugin-support.h"   // obs_log
 #include "window_tracker.h"   // sc_tracker_tick (Role A: 블랙리스트 앱 좌표 수집)
+#include <obs-frontend-api.h> // obs_hotkey_register_frontend
 #include <algorithm>
 #include <chrono>
 #include <stdlib.h>
@@ -309,6 +310,17 @@ bool AtomicMaskChannel::consume(MaskPayload& out)
 // Filter Lifecycle Callbacks
 // ================================================================
 
+// Panic 핫키 콜백 — 누를 때(pressed=true)만 토글. 해제 이벤트는 무시.
+static void panic_hotkey_cb(void* data, obs_hotkey_id, obs_hotkey_t*, bool pressed)
+{
+    if (!pressed)
+        return;
+    auto* filter = static_cast<SecureCastFilter*>(data);
+    bool next = !filter->panicMode.load(std::memory_order_relaxed);
+    filter->panicMode.store(next, std::memory_order_relaxed);
+    blog(LOG_INFO, "[SecureCast] Panic mode %s.", next ? "ON" : "OFF");
+}
+
 // OBS가 필터 메뉴/관리 UI에 표시할 이름.
 // 인자 type_data는 obs_source_info::type_data 필드 — 우리는 안 씀.
 static const char* securecast_get_name(void* type_data)
@@ -345,6 +357,25 @@ static void* securecast_create(obs_data_t* settings, obs_source_t* context)
     filter->winListener.start();
 #endif
 
+    // Panic 핫키 등록 (Ctrl+Shift+F12 기본 바인딩)
+    filter->panicHotkeyId = obs_hotkey_register_frontend(
+        "securecast_panic_toggle",
+        obs_module_text("PanicButton"),
+        panic_hotkey_cb, filter);
+    if (filter->panicHotkeyId != OBS_INVALID_HOTKEY_ID) {
+        obs_data_t*       combo = obs_data_create();
+        obs_data_array_t* arr   = obs_data_array_create();
+        obs_data_set_bool(combo,   "control", true);
+        obs_data_set_bool(combo,   "shift",   true);
+        obs_data_set_bool(combo,   "alt",     false);
+        obs_data_set_string(combo, "key",     "OBS_KEY_F12");
+        obs_data_array_push_back(arr, combo);
+        obs_hotkey_load(filter->panicHotkeyId, arr);
+        obs_data_array_release(arr);
+        obs_data_release(combo);
+        blog(LOG_INFO, "[SecureCast] Panic hotkey registered (Ctrl+Shift+F12).");
+    }
+
     // HLSL 셰이더 컴파일 (그래픽스 컨텍스트 필요)
     obs_enter_graphics();
     char *effect_path = obs_module_file("securecast_blur.effect");
@@ -368,6 +399,12 @@ static void securecast_destroy(void* data)
     SecureCastFilter* filter = static_cast<SecureCastFilter*>(data);
 
     blog(LOG_INFO, "Destroying filter...");
+
+    // 핫키 먼저 해제 — 콜백이 해제된 filter에 접근하지 못하도록
+    if (filter->panicHotkeyId != OBS_INVALID_HOTKEY_ID) {
+        obs_hotkey_unregister(filter->panicHotkeyId);
+        filter->panicHotkeyId = OBS_INVALID_HOTKEY_ID;
+    }
 
 #ifdef _WIN32
     filter->winListener.stop();
@@ -486,6 +523,39 @@ static void securecast_video_render(void* data, gs_effect_t* effect)
     MaskPayload newMask{};
     if (filter->maskChannel.consume(newMask))
         filter->lastMask = newMask;
+
+    // --- Panic Mode (Ctrl+Shift+F12) ---
+    // ring buffer는 계속 채우되 인코더로는 전체 블랙 + 빨간 테두리만 출력.
+    // 스트리머는 빨간 테두리로 패닉 활성 여부를 확인할 수 있다.
+    if (filter->panicMode.load(std::memory_order_relaxed)) {
+        gs_effect_t* solid = obs_get_base_effect(OBS_EFFECT_SOLID);
+
+        // 전체 블랙아웃
+        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFF000000);
+        while (gs_effect_loop(solid, "Solid"))
+            gs_draw_sprite(nullptr, 0, w, h);
+
+        // 빨간 테두리 6px
+        constexpr uint32_t BORDER = 6;
+        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFFFF0000);
+        while (gs_effect_loop(solid, "Solid")) {
+            gs_matrix_push(); gs_matrix_identity();
+            gs_draw_sprite(nullptr, 0, w, BORDER);                          // top
+            gs_matrix_pop();
+            gs_matrix_push(); gs_matrix_identity();
+            gs_matrix_translate3f(0.0f, (float)(h - BORDER), 0.0f);
+            gs_draw_sprite(nullptr, 0, w, BORDER);                          // bottom
+            gs_matrix_pop();
+            gs_matrix_push(); gs_matrix_identity();
+            gs_draw_sprite(nullptr, 0, BORDER, h);                          // left
+            gs_matrix_pop();
+            gs_matrix_push(); gs_matrix_identity();
+            gs_matrix_translate3f((float)(w - BORDER), 0.0f, 0.0f);
+            gs_draw_sprite(nullptr, 0, BORDER, h);                          // right
+            gs_matrix_pop();
+        }
+        return;
+    }
 
     // --- Step 4~5: N프레임 지연된 슬롯 꺼내기 ---
     const FrameRingBuffer::Slot* delayedSlot = filter->ringBuffer.peekDelayedSlot();

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -888,6 +888,7 @@ static void securecast_video_render(void* data, gs_effect_t* effect)
             gs_draw_sprite(nullptr, 0, GM_SZ, GM_SZ);
             gs_matrix_pop();
         }
+    }
 
     // Phase 4: Health Check & Reset
     if (filter->health.shouldReset()) {

--- a/src/securecast-filter.cpp
+++ b/src/securecast-filter.cpp
@@ -28,7 +28,50 @@
 #include <string.h>
 
 // window_tracker.cpp의 SCAN_INTERVAL_SEC(0.15f) 이상이면 즉시 스캔 트리거.
-static constexpr float SCAN_INTERVAL_FORCE = 1.0f;
+static constexpr float SCAN_INTERVAL_FORCE    = 1.0f;
+static constexpr float SCAN_INTERVAL_NORMAL   = 0.15f; // 일반 모드 스캔 주기
+static constexpr float SCAN_INTERVAL_GAME     = 0.5f;  // 게임 모드 스캔 주기
+
+// Game mode thresholds
+static constexpr float GM_CPU_ENTER     = 40.0f; // 진입 임계값 (%)
+static constexpr float GM_CPU_EXIT      = 30.0f; // 해제 임계값 (%)
+static constexpr float GM_ENTER_TIME    = 3.0f;  // 진입까지 ≥40% 유지 시간 (초)
+static constexpr float GM_EXIT_TIME     = 5.0f;  // 해제까지 ≤30%  유지 시간 (초)
+static constexpr float GM_SAMPLE_INTERVAL = 1.0f; // CPU 샘플링 주기 (초)
+
+// ================================================================
+// [Game Mode] GetSystemTimes 기반 시스템 전체 CPU 사용률 샘플링 (WIN32)
+//
+// GetSystemTimes: kernel 시간에 idle이 포함되므로
+//   CPU % = (kernel + user - idle) / (kernel + user) * 100
+// 멀티코어 기준 전체 평균값. 오버헤드 거의 0 (단순 syscall).
+// ================================================================
+#ifdef _WIN32
+static float sampleCpuUsage(FILETIME* prevIdle, FILETIME* prevKernel, FILETIME* prevUser)
+{
+    FILETIME idle, kernel, user;
+    if (!GetSystemTimes(&idle, &kernel, &user))
+        return 0.0f;
+
+    auto ft2u64 = [](FILETIME ft) -> uint64_t {
+        return (uint64_t(ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+    };
+
+    uint64_t idleDiff   = ft2u64(idle)   - ft2u64(*prevIdle);
+    uint64_t kernelDiff = ft2u64(kernel) - ft2u64(*prevKernel);
+    uint64_t userDiff   = ft2u64(user)   - ft2u64(*prevUser);
+
+    *prevIdle   = idle;
+    *prevKernel = kernel;
+    *prevUser   = user;
+
+    uint64_t total = kernelDiff + userDiff;
+    if (total == 0)
+        return 0.0f;
+
+    return (float)(total - idleDiff) / (float)total * 100.0f;
+}
+#endif
 
 // ================================================================
 // [Role A] 윈도우 좌표 → OBS 소스 픽셀 좌표 변환 + 15% BBox 팽창
@@ -258,20 +301,42 @@ void MockAIWorker::stop()
     blog(LOG_INFO, "MockAIWorker stopped.");
 }
 
+void MockAIWorker::setPaused(bool paused)
+{
+    if (!m_running.load())
+        return;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_paused.store(paused, std::memory_order_relaxed);
+    }
+    m_cv.notify_all();
+    blog(LOG_INFO, "MockAIWorker %s.", paused ? "paused" : "resumed");
+}
+
 void MockAIWorker::workerLoop()
 {
     while (m_running.load()) {
-        // AI 처리 시간 시뮬레이션 (실제 OCR 처리 예상 지연: ~40~60ms)
         {
             std::unique_lock<std::mutex> lock(m_mutex);
-            m_cv.wait_for(lock, std::chrono::milliseconds(50),
-                          [this]() { return !m_running.load(); });
+            if (m_paused.load(std::memory_order_relaxed)) {
+                // 게임 모드 일시정지: stop() 또는 resume 신호까지 대기
+                m_cv.wait(lock, [this]() {
+                    return !m_running.load() ||
+                           !m_paused.load(std::memory_order_relaxed);
+                });
+            } else {
+                // AI 처리 시간 시뮬레이션 (실제 OCR 처리 예상 지연: ~40~60ms)
+                m_cv.wait_for(lock, std::chrono::milliseconds(50), [this]() {
+                    return !m_running.load() ||
+                            m_paused.load(std::memory_order_relaxed);
+                });
+            }
         }
 
-        if (!m_running.load())
-            break;
+        if (!m_running.load() || m_paused.load(std::memory_order_relaxed))
+            continue;
 
-        // Role B(실제 OCR/AI) 미구현 — 빈 페이로드 전달 (중앙 박스 제거)
+        // Role B(실제 OCR/AI) 미구현 — 빈 페이로드 전달
         MaskPayload payload{};
         payload.rectCount = 0;
 
@@ -355,6 +420,8 @@ static void* securecast_create(obs_data_t* settings, obs_source_t* context)
 
 #ifdef _WIN32
     filter->winListener.start();
+    // CPU 샘플링 기준점 초기화 (첫 샘플에서 diff가 0이 되지 않도록)
+    GetSystemTimes(&filter->prevIdleTime, &filter->prevKernelTime, &filter->prevUserTime);
 #endif
 
     // Panic 핫키 등록 (Ctrl+Shift+F12 기본 바인딩)
@@ -615,28 +682,43 @@ static void securecast_video_render(void* data, gs_effect_t* effect)
                     all_count < (int)(sizeof(all_rects) / sizeof(all_rects[0])); i++)
         all_rects[all_count++] = filter->lastMask.rects[i];
 
-    if (all_count == 0)
-        return;
-
-    if (filter->blurEffect) {
-        // blur.effect 셰이더 사용 (Blur / Blackout technique)
-        for (int i = 0; i < all_count; i++)
-            render_blur_rect(filter->blurEffect, delayedTex, all_rects[i], w, h);
-    } else {
-        // 셰이더 로드 실패 시 fallback: 단색 검정 박스
-        gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
-        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFF000000);
-        gs_matrix_push();
-        while (gs_effect_loop(solid, "Solid")) {
-            for (int i = 0; i < all_count; i++) {
-                gs_matrix_identity();
-                gs_matrix_translate3f((float)all_rects[i].x, (float)all_rects[i].y, 0.0f);
-                gs_draw_sprite(nullptr, 0, (uint32_t)all_rects[i].width,
-                               (uint32_t)all_rects[i].height);
+    if (all_count > 0) {
+        if (filter->blurEffect) {
+            // blur.effect 셰이더 사용 (Blur / Blackout technique)
+            for (int i = 0; i < all_count; i++)
+                render_blur_rect(filter->blurEffect, delayedTex, all_rects[i], w, h);
+        } else {
+            // 셰이더 로드 실패 시 fallback: 단색 검정 박스
+            gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
+            gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFF000000);
+            gs_matrix_push();
+            while (gs_effect_loop(solid, "Solid")) {
+                for (int i = 0; i < all_count; i++) {
+                    gs_matrix_identity();
+                    gs_matrix_translate3f((float)all_rects[i].x, (float)all_rects[i].y, 0.0f);
+                    gs_draw_sprite(nullptr, 0, (uint32_t)all_rects[i].width,
+                                   (uint32_t)all_rects[i].height);
+                }
             }
+            gs_matrix_pop();
         }
-        gs_matrix_pop();
     }
+
+#ifdef _WIN32
+    // 게임 모드 활성 시: 우상단에 빨간 네모 박스 표시 (임시 인디케이터)
+    if (filter->isGameMode) {
+        gs_effect_t* solid = obs_get_base_effect(OBS_EFFECT_SOLID);
+        constexpr uint32_t GM_SZ = 20, GM_PAD = 8;
+        gs_effect_set_color(gs_effect_get_param_by_name(solid, "color"), 0xFFFF0000);
+        while (gs_effect_loop(solid, "Solid")) {
+            gs_matrix_push();
+            gs_matrix_identity();
+            gs_matrix_translate3f((float)(w - GM_SZ - GM_PAD), (float)GM_PAD, 0.0f);
+            gs_draw_sprite(nullptr, 0, GM_SZ, GM_SZ);
+            gs_matrix_pop();
+        }
+    }
+#endif
 }
 // ---------------------------------------------------------
 // Tick (Slow-Path) — 매 프레임 호출되지만 윈도우 추적은 0.15초마다
@@ -655,6 +737,46 @@ static void securecast_video_tick(void* data, float seconds)
         return;
 
 #ifdef _WIN32
+    // ── CPU 샘플링 & 게임 모드 상태머신 (1초 주기) ──────────────────────
+    filter->cpuSampleAccumulator += seconds;
+    if (filter->cpuSampleAccumulator >= GM_SAMPLE_INTERVAL) {
+        filter->cpuSampleAccumulator = 0.0f;
+        filter->cpuUsage = sampleCpuUsage(&filter->prevIdleTime,
+                                           &filter->prevKernelTime,
+                                           &filter->prevUserTime);
+
+        if (!filter->isGameMode) {
+            if (filter->cpuUsage >= GM_CPU_ENTER) {
+                filter->gameModeEntryTimer += GM_SAMPLE_INTERVAL;
+                if (filter->gameModeEntryTimer >= GM_ENTER_TIME) {
+                    filter->isGameMode        = true;
+                    filter->gameModeEntryTimer = 0.0f;
+                    filter->gameModeExitTimer  = 0.0f;
+                    filter->mockWorker.setPaused(true);
+                    blog(LOG_INFO, "[SecureCast] Game mode ON  (CPU: %.0f%%)", filter->cpuUsage);
+                }
+            } else {
+                filter->gameModeEntryTimer = 0.0f;
+            }
+        } else {
+            if (filter->cpuUsage <= GM_CPU_EXIT) {
+                filter->gameModeExitTimer += GM_SAMPLE_INTERVAL;
+                if (filter->gameModeExitTimer >= GM_EXIT_TIME) {
+                    filter->isGameMode       = false;
+                    filter->gameModeExitTimer = 0.0f;
+                    filter->mockWorker.setPaused(false);
+                    blog(LOG_INFO, "[SecureCast] Game mode OFF (CPU: %.0f%%, 10s cooldown)", filter->cpuUsage);
+                }
+            } else {
+                filter->gameModeExitTimer = 0.0f;
+            }
+        }
+    }
+
+    // ── WinEvent: 포그라운드 전환 감지 → Quick Restore ─
+    // 게임 모드는 CPU 임계값(<30%, 10s)으로만 해제한다.
+    // WinEvent로 해제하면 게임 실행 중 발생하는 내부 창 이벤트(알림, 팝업 등)에
+    // 의해 게임 모드가 즉시 끊겼다가 3초 후 재진입하는 깜빡임이 발생한다.
     if (filter->winListener.checkAndClearRescan()) {
         filter->trackerAccumulator = SCAN_INTERVAL_FORCE;
 
@@ -676,7 +798,6 @@ static void securecast_video_tick(void* data, float seconds)
                 if (!alreadyTracked && filter->windowList.count < SC_MAX_TRACKED_WINDOWS) {
                     const TrackedWindow& tw = filter->recentlySeenList.items[ri];
                     filter->windowList.items[filter->windowList.count++] = tw;
-                    // captureWindowList에도 즉시 반영: 이번 render pushFrame 스냅샷에 포함
                     if (filter->captureWindowList.count < SC_MAX_TRACKED_WINDOWS)
                         filter->captureWindowList.items[filter->captureWindowList.count++] = tw;
                     // Quick restore 성공: 즉시 강제 스캔을 하지 않는다.
@@ -691,7 +812,9 @@ static void securecast_video_tick(void* data, float seconds)
             }
         }
     }
-    sc_tracker_tick(seconds, &filter->trackerAccumulator, &filter->windowList);
+
+    const float scanInterval = filter->isGameMode ? SCAN_INTERVAL_GAME : SCAN_INTERVAL_NORMAL;
+    sc_tracker_tick(seconds, &filter->trackerAccumulator, &filter->windowList, scanInterval);
 
     // recentlySeenList 유지: windowList 항목을 upsert, 완전히 닫힌 HWND 제거.
     // recentlySeenList는 앱이 다시 등장했을 때 quick restore의 소스가 된다.

--- a/src/securecast-filter.h
+++ b/src/securecast-filter.h
@@ -246,6 +246,10 @@ struct SecureCastFilter {
     int               lingeringCount = 0;
 #endif
 
+    // ----- [Panic Button] Ctrl+Shift+F12 -----
+    std::atomic<bool> panicMode{false};
+    obs_hotkey_id     panicHotkeyId = OBS_INVALID_HOTKEY_ID;
+
     // ----- TODO: Role B 담당 필드 -----
     // void* ocrEngine = nullptr;           // Windows.Media.Ocr 엔진 포인터
 };

--- a/src/securecast-filter.h
+++ b/src/securecast-filter.h
@@ -31,6 +31,14 @@
 #include <obs-module.h>
 
 // ----------------------------------------------------
+// Platform Headers
+// ----------------------------------------------------
+#ifdef _WIN32
+#include "win_event_listener.h"
+#include "window_tracker.h"
+#endif
+
+// ----------------------------------------------------
 // Helpers & Macros
 // ----------------------------------------------------
 
@@ -71,6 +79,15 @@ struct MaskPayload {
     int rectCount;
 };
 
+#ifdef _WIN32
+// 창이 사라진 후 ring buffer에 남은 N프레임 동안 마스킹을 유지하는 잔영 항목.
+struct LingeringWindow {
+    TrackedWindow window;         // 마지막으로 알려진 창 정보 (bounds 포함)
+    int           ticksRemaining; // SC_RING_BUFFER_SLOTS에서 매 tick 카운트다운
+};
+constexpr int SC_MAX_LINGERING = SC_MAX_TRACKED_WINDOWS;
+#endif
+
 // ----------------------------------------------------
 // [Role C] N-Frame Ring Buffer
 // 
@@ -90,6 +107,11 @@ public:
     struct Slot {
         gs_texrender_t* texrender = nullptr; // OBS 안전 렌더 타겟 관리자
         uint64_t        timestamp = 0;
+#ifdef _WIN32
+        // 이 프레임이 캡처된 시점의 창 좌표 스냅샷.
+        // 렌더 시 delayedSlot->windowSnapshot을 사용해야 프레임 내용과 마스크 위치가 동기화됨.
+        TrackedWindowList windowSnapshot{};
+#endif
 
         // gs_texrender에서 결과 텍스처를 꺼내는 헬퍼
         gs_texture_t* getTexture() const {
@@ -104,10 +126,18 @@ public:
     bool initialize(uint32_t width, uint32_t height);
     void destroy();
 
-    // gs_texrender_begin/end를 사용하여 안전하게 프레임을 캡처
+    // gs_texrender_begin/end를 사용하여 안전하게 프레임을 캡처.
+    // wlist: 이 프레임 캡처 시점의 창 좌표 스냅샷 (null 허용).
+#ifdef _WIN32
+    void pushFrame(obs_source_t* source, uint64_t timestamp, const TrackedWindowList* wlist);
+#else
     void pushFrame(obs_source_t* source, uint64_t timestamp);
+#endif
 
     const Slot* peekDelayedSlot() const;
+    // framesBack=SC_RING_BUFFER_SLOTS이면 peekDelayedSlot()과 동일.
+    // framesBack=SC_RING_BUFFER_SLOTS-1이면 한 프레임 더 최신 슬롯 (빠른 이동 합집합용).
+    const Slot* peekSlotAtOffset(int framesBack) const;
 
     bool isInitialized() const { return m_initialized; }
     uint32_t getWidth()  const { return m_width;  }
@@ -194,6 +224,9 @@ struct SecureCastFilter {
     bool          isGameMode  = false;
     SecurityState currentState = SecurityState::SAFE;
 
+    // ----- [Role A] HLSL 마스킹 셰이더 -----
+    gs_effect_t*  blurEffect  = nullptr; // data/securecast_blur.effect 컴파일 결과
+
     // ----- [Role C] 담당 필드 -----
     FrameRingBuffer  ringBuffer;    // N-Frame 지연 버퍼
     MockAIWorker     mockWorker;    // 가짜 AI 워커 스레드
@@ -203,6 +236,15 @@ struct SecureCastFilter {
     // ----- [Role A] 담당 필드 -----
     float         trackerAccumulator = 0.0f; // window_tracker tick throttle 누산기
     // gs_effect_t* blurEffect = nullptr;  // 컴파일된 HLSL 셰이더
+#ifdef _WIN32
+    WinEventListener  winListener;
+    TrackedWindowList windowList{};          // 마지막 slow-scan 결과 (sc_tracker_tick 갱신)
+    TrackedWindowList captureWindowList{};   // pushFrame에 쓰는 스냅샷: 직전 프레임 DWM 좌표
+                                             // OBS 소스 캡처 ~1프레임 레이턴시 보정용
+    TrackedWindowList prevWindowList{};      // lingering 감지용 직전 스캔 결과
+    LingeringWindow   lingeringWindows[SC_MAX_LINGERING]{};
+    int               lingeringCount = 0;
+#endif
 
     // ----- TODO: Role B 담당 필드 -----
     // void* ocrEngine = nullptr;           // Windows.Media.Ocr 엔진 포인터

--- a/src/securecast-filter.h
+++ b/src/securecast-filter.h
@@ -238,7 +238,9 @@ struct SecureCastFilter {
 
     // ----- [Role A 담당: 윈도우 추적 및 블랙리스트] -----
     float         trackerAccumulator = 0.0f; // 윈도우 스캔 틱 조절(0.15초 단위)용 시간 누산기
-    // gs_effect_t* blurEffect = nullptr;  // 컴파일된 HLSL 셰이더
+    gs_effect_t*  blurEffect = nullptr;      // 컴파일된 HLSL 셰이더
+    std::mutex    blacklistMutex;            // video_tick(비디오)과 video_render(렌더) 간의 동시 접근을 막는 뮤텍스
+    MaskPayload   blacklistMask{};           // [우선순위 1] Role A가 추적한 블랙리스트 앱 좌표 (AI 처리 전에 최상단에 덮어씌움)
 #ifdef _WIN32
     WinEventListener  winListener;
     TrackedWindowList windowList{};          // 현재 추적 중인 창 목록

--- a/src/securecast-filter.h
+++ b/src/securecast-filter.h
@@ -238,10 +238,10 @@ struct SecureCastFilter {
     // gs_effect_t* blurEffect = nullptr;  // 컴파일된 HLSL 셰이더
 #ifdef _WIN32
     WinEventListener  winListener;
-    TrackedWindowList windowList{};          // 마지막 slow-scan 결과 (sc_tracker_tick 갱신)
-    TrackedWindowList captureWindowList{};   // pushFrame에 쓰는 스냅샷: 직전 프레임 DWM 좌표
-                                             // OBS 소스 캡처 ~1프레임 레이턴시 보정용
+    TrackedWindowList windowList{};          // 현재 추적 중인 창 목록
+    TrackedWindowList captureWindowList{};   // pushFrame 스냅샷: 직전 프레임 DWM 좌표 (캡처 레이턴시 보정)
     TrackedWindowList prevWindowList{};      // lingering 감지용 직전 스캔 결과
+    TrackedWindowList recentlySeenList{};    // 과거에 추적했던 창 목록 (quick restore용, 닫힐 때까지 유지)
     LingeringWindow   lingeringWindows[SC_MAX_LINGERING]{};
     int               lingeringCount = 0;
 #endif

--- a/src/securecast-filter.h
+++ b/src/securecast-filter.h
@@ -171,14 +171,17 @@ public:
     // 워커 스레드 시작. frameWidth/Height로 가짜 중앙 좌표를 계산한다.
     void start(uint32_t frameWidth, uint32_t frameHeight, ResultCallback callback);
     void stop();
+    void setPaused(bool paused);
 
     bool isRunning() const { return m_running.load(); }
+    bool isPaused()  const { return m_paused.load();  }
 
 private:
     void workerLoop();
 
     std::thread             m_thread;
     std::atomic<bool>       m_running{false};
+    std::atomic<bool>       m_paused{false};
     std::mutex              m_mutex;
     std::condition_variable m_cv;
 
@@ -244,6 +247,15 @@ struct SecureCastFilter {
     TrackedWindowList recentlySeenList{};    // 과거에 추적했던 창 목록 (quick restore용, 닫힐 때까지 유지)
     LingeringWindow   lingeringWindows[SC_MAX_LINGERING]{};
     int               lingeringCount = 0;
+
+    // ----- [Game Mode] CPU 사용률 기반 자동 전환 -----
+    float    cpuSampleAccumulator = 0.0f; // 1초 샘플링 누산기
+    float    cpuUsage             = 0.0f; // 최근 측정 시스템 CPU 사용률 (0~100)
+    float    gameModeEntryTimer   = 0.0f; // ≥40% 지속 시간 누산 (3초 도달 시 진입)
+    float    gameModeExitTimer    = 0.0f; // <30% 지속 시간 누산 (10초 도달 시 해제)
+    FILETIME prevIdleTime         = {};   // GetSystemTimes 이전 샘플
+    FILETIME prevKernelTime       = {};
+    FILETIME prevUserTime         = {};
 #endif
 
     // ----- [Panic Button] Ctrl+Shift+F12 -----

--- a/src/win_event_listener.cpp
+++ b/src/win_event_listener.cpp
@@ -1,0 +1,104 @@
+// =============================================================================
+// win_event_listener.cpp — SetWinEventHook listener 구현
+// =============================================================================
+
+#ifdef _WIN32
+
+#include "win_event_listener.h"
+#include "plugin-support.h"
+#include <obs.h>            // blog, LOG_INFO/ERROR
+
+std::atomic<WinEventListener*> WinEventListener::s_active{nullptr};
+
+void WinEventListener::start()
+{
+    bool expected = false;
+    if (!m_running.compare_exchange_strong(expected, true))
+        return; // 이미 동작 중
+
+    // 한 번에 한 인스턴스만 글로벌 active 로 설정. 나머지는 보조 (이벤트 받지 않음).
+    WinEventListener* expectedActive = nullptr;
+    s_active.compare_exchange_strong(expectedActive, this);
+
+    m_thread = std::thread([this]() { run(); });
+}
+
+void WinEventListener::stop()
+{
+    bool expected = true;
+    if (!m_running.compare_exchange_strong(expected, false))
+        return;
+
+    // 스레드 깨우기: 메시지 펌프에 WM_QUIT 보냄.
+    if (m_threadId)
+        PostThreadMessage(m_threadId, WM_QUIT, 0, 0);
+
+    if (m_thread.joinable())
+        m_thread.join();
+
+    WinEventListener* expectedActive = this;
+    s_active.compare_exchange_strong(expectedActive, nullptr);
+}
+
+void WinEventListener::run()
+{
+    m_threadId = GetCurrentThreadId();
+
+    // 그룹 1: 등장/사라짐/소멸 (드물게 발생, 모든 윈도우 대상)
+    // EVENT_OBJECT_SHOW, EVENT_OBJECT_HIDE, EVENT_OBJECT_DESTROY 가 이 범위에 들어감.
+    m_hookGroup1 = SetWinEventHook(
+        EVENT_OBJECT_SHOW, EVENT_OBJECT_DESTROY,
+        nullptr, eventProc, 0, 0,
+        WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+
+    // [의도적으로 LOCATIONCHANGE 후킹하지 않음]
+    // EVENT_OBJECT_LOCATIONCHANGE 는 마우스 커서 / UI 갱신 / 모든 윈도우 이동에 발생해
+    // 1초당 수천 번 콜백. 모든 콜백이 needRescan flag 를 set 하면 매 video_tick 마다
+    // 풀 스캔 (EnumWindows + OpenProcess) 이 돌아 CPU 가 폭주한다 (관측: 일반 25%,
+    // 게임 중 70%). 위치 변경은 매 tick (60Hz) 의 sc_get_window_visible_bounds 폴링
+    // 으로 처리. 게임 중 빠른 이동 노출은 4주차 게임 모드 (적응형 마진 등) 로 별도 처리.
+    m_hookGroup2 = nullptr;
+
+    if (!m_hookGroup1) {
+        blog(LOG_ERROR, "[SecureCast] SetWinEventHook failed; falling back to polling only.");
+    } else {
+        blog(LOG_INFO, "[SecureCast] WinEventListener started (SHOW/HIDE/DESTROY only).");
+    }
+
+    // 메시지 펌프 — WINEVENT_OUTOFCONTEXT 콜백은 이 펌프에서 dispatch 됨.
+    MSG msg{};
+    while (m_running.load(std::memory_order_acquire)) {
+        BOOL ret = GetMessage(&msg, nullptr, 0, 0);
+        if (ret <= 0) // WM_QUIT 또는 에러
+            break;
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    if (m_hookGroup1) UnhookWinEvent(m_hookGroup1);
+    if (m_hookGroup2) UnhookWinEvent(m_hookGroup2);
+    m_hookGroup1 = nullptr;
+    m_hookGroup2 = nullptr;
+    m_threadId   = 0;
+
+    blog(LOG_INFO, "[SecureCast] WinEventListener stopped.");
+}
+
+void CALLBACK WinEventListener::eventProc(HWINEVENTHOOK /*hHook*/, DWORD /*event*/,
+                                          HWND hwnd, LONG idObject, LONG idChild,
+                                          DWORD /*idEventThread*/, DWORD /*dwmsEventTime*/)
+{
+    // OBJID_WINDOW + CHILDID_SELF 만 처리 (탑레벨 윈도우 자체 이벤트).
+    // 그 외 (메뉴, 컨트롤, 캐럿 등) 는 노이즈.
+    if (idObject != OBJID_WINDOW || idChild != CHILDID_SELF || hwnd == nullptr)
+        return;
+
+    WinEventListener* self = s_active.load(std::memory_order_acquire);
+    if (!self)
+        return;
+
+    // 단순 flag set. 무거운 작업은 video_tick 에서.
+    self->m_needRescan.store(true, std::memory_order_release);
+}
+
+#endif // _WIN32

--- a/src/win_event_listener.cpp
+++ b/src/win_event_listener.cpp
@@ -45,24 +45,23 @@ void WinEventListener::run()
     m_threadId = GetCurrentThreadId();
 
     // 그룹 1: 등장/사라짐/소멸 (드물게 발생, 모든 윈도우 대상)
-    // EVENT_OBJECT_SHOW, EVENT_OBJECT_HIDE, EVENT_OBJECT_DESTROY 가 이 범위에 들어감.
     m_hookGroup1 = SetWinEventHook(
         EVENT_OBJECT_SHOW, EVENT_OBJECT_DESTROY,
         nullptr, eventProc, 0, 0,
         WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
 
-    // [의도적으로 LOCATIONCHANGE 후킹하지 않음]
-    // EVENT_OBJECT_LOCATIONCHANGE 는 마우스 커서 / UI 갱신 / 모든 윈도우 이동에 발생해
-    // 1초당 수천 번 콜백. 모든 콜백이 needRescan flag 를 set 하면 매 video_tick 마다
-    // 풀 스캔 (EnumWindows + OpenProcess) 이 돌아 CPU 가 폭주한다 (관측: 일반 25%,
-    // 게임 중 70%). 위치 변경은 매 tick (60Hz) 의 sc_get_window_visible_bounds 폴링
-    // 으로 처리. 게임 중 빠른 이동 노출은 4주차 게임 모드 (적응형 마진 등) 로 별도 처리.
-    m_hookGroup2 = nullptr;
+    // 그룹 2: 포그라운드 변경 — 카톡이 앞으로 오거나 다른 앱이 앞으로 와서 카톡이
+    // 뒤로 가는 순간을 감지. EVENT_OBJECT_LOCATIONCHANGE(위치 이동)와 달리 포그라운드
+    // 전환은 드물게 발생하므로 CPU 부담 없이 추가 가능.
+    m_hookGroup2 = SetWinEventHook(
+        EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND,
+        nullptr, eventProc, 0, 0,
+        WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
 
     if (!m_hookGroup1) {
         blog(LOG_ERROR, "[SecureCast] SetWinEventHook failed; falling back to polling only.");
     } else {
-        blog(LOG_INFO, "[SecureCast] WinEventListener started (SHOW/HIDE/DESTROY only).");
+        blog(LOG_INFO, "[SecureCast] WinEventListener started (SHOW/HIDE/DESTROY + FOREGROUND).");
     }
 
     // 메시지 펌프 — WINEVENT_OUTOFCONTEXT 콜백은 이 펌프에서 dispatch 됨.

--- a/src/win_event_listener.h
+++ b/src/win_event_listener.h
@@ -57,7 +57,7 @@ private:
     std::atomic<bool> m_running{false};
     DWORD             m_threadId    = 0;
     HWINEVENTHOOK     m_hookGroup1  = nullptr; // SHOW / HIDE / DESTROY
-    HWINEVENTHOOK     m_hookGroup2  = nullptr; // LOCATIONCHANGE
+    HWINEVENTHOOK     m_hookGroup2  = nullptr; // SYSTEM_FOREGROUND (포그라운드 전환)
 
     std::atomic<bool> m_needRescan{false};
 

--- a/src/win_event_listener.h
+++ b/src/win_event_listener.h
@@ -1,0 +1,68 @@
+// =============================================================================
+// win_event_listener.h — SetWinEventHook 기반 push 감지 (Role A 4주차 사전작업)
+//
+// 가이드 §5.1 권장 구조: 별도 스레드 + 메시지 펌프 + WINEVENT_OUTOFCONTEXT.
+// EVENT_OBJECT_SHOW / HIDE / DESTROY / LOCATIONCHANGE 를 후킹해 OS 이벤트가
+// 도착할 때마다 atomic needRescan 플래그를 set. 다음 video_tick 에서 그 플래그를
+// 보고 풀 스캔 throttle 을 무시하고 즉시 처리.
+//
+// 효과:
+//   - 카톡 등장/사라짐/위치변경 평균 latency 50ms → ~16ms (1 video_tick)
+//   - 풀 스캔 throttle 을 더 길게 (예: 500ms) 잡아도 push 로 즉시 반응 → CPU 절감
+//
+// 안전성:
+//   - WINEVENT_OUTOFCONTEXT 는 DLL 인젝션 없이 OS 이벤트만 받는 안전 모드
+//   - WINEVENT_SKIPOWNPROCESS 로 자기 자신 이벤트 제외 (loop 방지)
+//
+// 사용:
+//   filter->listener.start();          // 보통 securecast_create
+//   if (filter->listener.checkAndClearRescan()) { /* 즉시 풀 스캔 */ }
+//   filter->listener.stop();           // securecast_destroy
+//
+// 멀티 인스턴스: 현재 글로벌 atomic 1개 사용 → 사실상 인스턴스 1개 가정.
+//                추가 인스턴스가 등록되면 그쪽도 동일 콜백을 공유.
+// =============================================================================
+#pragma once
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <atomic>
+#include <thread>
+
+class WinEventListener {
+public:
+    WinEventListener() = default;
+    ~WinEventListener() { stop(); }
+
+    WinEventListener(const WinEventListener&)            = delete;
+    WinEventListener& operator=(const WinEventListener&) = delete;
+
+    void start();
+    void stop();
+
+    // video_tick 에서 호출. 이벤트가 한 번이라도 있었으면 true 를 반환하면서 flag 리셋.
+    bool checkAndClearRescan() {
+        return m_needRescan.exchange(false, std::memory_order_acq_rel);
+    }
+
+private:
+    void run();
+
+    static void CALLBACK eventProc(HWINEVENTHOOK hHook, DWORD event, HWND hwnd,
+                                   LONG idObject, LONG idChild,
+                                   DWORD idEventThread, DWORD dwmsEventTime);
+
+    std::thread       m_thread;
+    std::atomic<bool> m_running{false};
+    DWORD             m_threadId    = 0;
+    HWINEVENTHOOK     m_hookGroup1  = nullptr; // SHOW / HIDE / DESTROY
+    HWINEVENTHOOK     m_hookGroup2  = nullptr; // LOCATIONCHANGE
+
+    std::atomic<bool> m_needRescan{false};
+
+    // 콜백에서 도달하기 위한 스레드별 self 포인터 (한 프로세스에 instance 1개 가정).
+    static std::atomic<WinEventListener*> s_active;
+};
+
+#endif // _WIN32

--- a/src/window_tracker.cpp
+++ b/src/window_tracker.cpp
@@ -158,6 +158,28 @@ BOOL CALLBACK enum_proc(HWND hwnd, LPARAM lparam)
 
 } // namespace
 
+extern "C" void sc_update_tracked_bounds(TrackedWindowList *list)
+{
+	if (!list || list->count == 0)
+		return;
+
+	// 역순으로 순회해야 swap-and-pop 시 인덱스가 안 틀린다.
+	for (int i = list->count - 1; i >= 0; --i) {
+		HWND hwnd = list->items[i].hwnd;
+
+		// 창이 닫혔거나 최소화됐으면 슬롯 제거 (마지막 원소와 swap-and-pop).
+		if (!IsWindowVisible(hwnd)) {
+			list->items[i] = list->items[--list->count];
+			continue;
+		}
+
+		RECT rect{};
+		if (SUCCEEDED(DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS,
+		                                    &rect, sizeof(rect))))
+			list->items[i].bounds = rect;
+	}
+}
+
 // 호출자는 OBS의 video_tick / video_render 같은 렌더 스레드 컨텍스트에서만 호출할 것.
 // (DWM/Win32 윈도우 핸들 조회는 caller 스레드의 메시지 큐에 의존)
 extern "C" void sc_scan_blacklisted_windows(TrackedWindowList *out)
@@ -170,7 +192,7 @@ extern "C" void sc_scan_blacklisted_windows(TrackedWindowList *out)
 
 // 60fps tick에서 매번 호출되어도 실제 무거운 EnumWindows는 0.15초마다 1회만 실행.
 // 매칭된 창은 일단 obs_log로만 출력 — 후속 단계에서 BlurRect로 변환 후 셰이더에 전달.
-extern "C" void sc_tracker_tick(float seconds, float *accumulator)
+extern "C" void sc_tracker_tick(float seconds, float *accumulator, TrackedWindowList *out)
 {
 	if (!accumulator)
 		return;
@@ -183,10 +205,13 @@ extern "C" void sc_tracker_tick(float seconds, float *accumulator)
 	TrackedWindowList list{};
 	sc_scan_blacklisted_windows(&list);
 
+	// 스캔 결과를 호출자에게 전달 (창이 0개여도 업데이트 — 닫힌 창 반영).
+	if (out)
+		*out = list;
+
 	if (list.count == 0)
 		return;
 
-	// 디버그 출력. 운영 단계에서는 빈도 줄이거나 LOG_DEBUG로 강등 예정.
 	for (int i = 0; i < list.count; ++i) {
 		const auto &w = list.items[i];
 		obs_log(LOG_INFO, "[tracker] %ls @ (%ld,%ld)-(%ld,%ld) %ldx%ld", w.exe_name,

--- a/src/window_tracker.cpp
+++ b/src/window_tracker.cpp
@@ -104,26 +104,32 @@ bool is_task_switcher_window(HWND hwnd)
 	return false;
 }
 
-// 창 중앙점이 실제로 그 창의 표면에 있는지 확인 (다른 앱에 가려져 있으면 false).
-// 뒤로 보내기 상태 감지에 사용. GetAncestor(GA_ROOT)로 최상위 윈도우까지 올라가
-// 우리가 추적 중인 hwnd와 같은지 비교한다.
-// Task View / Alt+Tab이 앞에 있으면 true 반환 (전환 중에도 마스킹 유지).
+// 창이 다른 앱에 완전히 가려져 있는지 확인 (뒤로 보내기 감지).
+// 중앙 1점이 아니라 5점(중앙 + 4코너 25% 안쪽)을 샘플링해,
+// 하나라도 hwnd가 최상위이면 true 반환.
+// 완전히 다른 앱에 덮여야(5점 모두 다른 창) 추적 해제.
 bool is_window_top_at_center(HWND hwnd, const RECT &rect)
 {
-	POINT center = {
-		(rect.left + rect.right) / 2,
-		(rect.top + rect.bottom) / 2
+	const LONG w4 = (rect.right  - rect.left) / 4;
+	const LONG h4 = (rect.bottom - rect.top)  / 4;
+	const POINT samples[5] = {
+		{ (rect.left + rect.right) / 2,  (rect.top + rect.bottom) / 2 }, // center
+		{ rect.left  + w4,               rect.top  + h4               }, // top-left
+		{ rect.right - w4,               rect.top  + h4               }, // top-right
+		{ rect.left  + w4,               rect.bottom - h4             }, // bottom-left
+		{ rect.right - w4,               rect.bottom - h4             }, // bottom-right
 	};
-	HWND topAt = WindowFromPoint(center);
-	if (!topAt)
-		return true;
-	HWND topRoot = GetAncestor(topAt, GA_ROOT);
-	if (topRoot == hwnd)
-		return true;
-	// Task View/Alt+Tab이 앞에 있으면 추적 유지 (전환 UI → 마스킹 계속 필요)
-	if (is_task_switcher_window(topRoot))
-		return true;
-	return false; // 다른 일반 앱이 앞에 있음 → 뒤로 보내기로 간주
+	for (const POINT &pt : samples) {
+		HWND topAt = WindowFromPoint(pt);
+		if (!topAt)
+			return true;
+		HWND topRoot = GetAncestor(topAt, GA_ROOT);
+		if (topRoot == hwnd)
+			return true;
+		if (is_task_switcher_window(topRoot))
+			return true;
+	}
+	return false; // 5개 샘플점 모두 다른 앱에 가려짐 → 뒤로 보내기로 간주
 }
 
 // EnumWindows의 콜백. 시스템의 모든 최상위 윈도우에 대해 한 번씩 호출됨.
@@ -242,13 +248,13 @@ extern "C" void sc_scan_blacklisted_windows(TrackedWindowList *out)
 
 // 60fps tick에서 매번 호출되어도 실제 무거운 EnumWindows는 0.15초마다 1회만 실행.
 // 매칭된 창은 일단 obs_log로만 출력 — 후속 단계에서 BlurRect로 변환 후 셰이더에 전달.
-extern "C" void sc_tracker_tick(float seconds, float *accumulator, TrackedWindowList *out)
+extern "C" void sc_tracker_tick(float seconds, float *accumulator, TrackedWindowList *out, float interval)
 {
 	if (!accumulator)
 		return;
 
 	*accumulator += seconds;
-	if (*accumulator < SCAN_INTERVAL_SEC)
+	if (*accumulator < interval)
 		return;
 	*accumulator = 0.0f;
 

--- a/src/window_tracker.cpp
+++ b/src/window_tracker.cpp
@@ -32,8 +32,8 @@ namespace {
 
 constexpr int MIN_WINDOW_DIMENSION = 100;
 
-// EnumWindows 1회의 비용을 60fps 매 tick 떠안기엔 부담. 사람의 창 이동 인지
-// 시간보다 짧으면 충분하므로 0.15초 (≈6.7Hz) 로 둔다.
+// 기본 스캔 주기 참조값 (일반 모드). 실제 스캔 주기는 sc_tracker_tick의 interval 인자로 전달된다.
+// 게임 모드에서는 호출자(securecast-filter.cpp)가 SCAN_INTERVAL_GAME(0.5초)을 전달한다.
 constexpr float SCAN_INTERVAL_SEC = 0.15f;
 
 // 보호 대상 앱 목록. 향후 OBS Properties UI에서 사용자가 편집할 수 있게 확장 예정.

--- a/src/window_tracker.cpp
+++ b/src/window_tracker.cpp
@@ -30,7 +30,6 @@
 
 namespace {
 
-// 너무 작은 창은 시각적으로 노출 가능성이 낮고, 트레이 아이콘 같은 노이즈가 많다.
 constexpr int MIN_WINDOW_DIMENSION = 100;
 
 // EnumWindows 1회의 비용을 60fps 매 tick 떠안기엔 부담. 사람의 창 이동 인지
@@ -88,6 +87,45 @@ bool is_blacklisted(const wchar_t *exe_name)
 	return false;
 }
 
+// Win+Tab(Task View)나 Alt+Tab(앱 전환기)인지 클래스명으로 판별.
+// 이 창이 앞에 있을 때는 뒤에 있는 민감 앱을 추적 해제하지 않는다.
+// 이유: Task View/Alt+Tab은 전환 UI이므로, 그 뒤의 민감 앱은 "선택 중인 상태"일 수 있고
+//       전환 애니메이션(~500ms) 동안도 마스킹을 유지해야 즉시 가려진다.
+bool is_task_switcher_window(HWND hwnd)
+{
+	wchar_t cls[128] = {};
+	GetClassNameW(hwnd, cls, 128);
+	// Win+Tab Task View (Windows 10 / 11)
+	if (wcsstr(cls, L"MultitaskingView") != nullptr)
+		return true;
+	// Alt+Tab 앱 전환기 (버전마다 클래스명 다름)
+	if (iequals(cls, L"TaskSwitcherWnd") || iequals(cls, L"XamlExplorerHostIslandWindow"))
+		return true;
+	return false;
+}
+
+// 창 중앙점이 실제로 그 창의 표면에 있는지 확인 (다른 앱에 가려져 있으면 false).
+// 뒤로 보내기 상태 감지에 사용. GetAncestor(GA_ROOT)로 최상위 윈도우까지 올라가
+// 우리가 추적 중인 hwnd와 같은지 비교한다.
+// Task View / Alt+Tab이 앞에 있으면 true 반환 (전환 중에도 마스킹 유지).
+bool is_window_top_at_center(HWND hwnd, const RECT &rect)
+{
+	POINT center = {
+		(rect.left + rect.right) / 2,
+		(rect.top + rect.bottom) / 2
+	};
+	HWND topAt = WindowFromPoint(center);
+	if (!topAt)
+		return true;
+	HWND topRoot = GetAncestor(topAt, GA_ROOT);
+	if (topRoot == hwnd)
+		return true;
+	// Task View/Alt+Tab이 앞에 있으면 추적 유지 (전환 UI → 마스킹 계속 필요)
+	if (is_task_switcher_window(topRoot))
+		return true;
+	return false; // 다른 일반 앱이 앞에 있음 → 뒤로 보내기로 간주
+}
+
 // EnumWindows의 콜백. 시스템의 모든 최상위 윈도우에 대해 한 번씩 호출됨.
 // 반환:
 //   TRUE  → 다음 윈도우로 계속 순회
@@ -143,6 +181,11 @@ BOOL CALLBACK enum_proc(HWND hwnd, LPARAM lparam)
 	if (!is_blacklisted(exe_name))
 		return TRUE;
 
+	// Z-order: 창 중앙이 다른 앱에 가려져 있으면 (뒤로 보내기 상태) 추적 대상 제외.
+	// 카톡이 OBS 뒤로 가도 IsWindowVisible=true라 이 체크 없이는 계속 추적된다.
+	if (!is_window_top_at_center(hwnd, rect))
+		return TRUE;
+
 	// 매칭 성공 → out 슬롯에 정보 복사.
 	auto &slot = out->items[out->count++];
 	slot.hwnd = hwnd;
@@ -177,6 +220,13 @@ extern "C" void sc_update_tracked_bounds(TrackedWindowList *list)
 		if (SUCCEEDED(DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS,
 		                                    &rect, sizeof(rect))))
 			list->items[i].bounds = rect;
+
+		// 다른 앱 창이 앞으로 와서 이 창을 가리면 즉시 추적 해제.
+		// 뒤로 보내기는 IsWindowVisible=true를 유지하므로 위의 체크만으로는 감지 불가.
+		if (!is_window_top_at_center(hwnd, list->items[i].bounds)) {
+			list->items[i] = list->items[--list->count];
+			continue;
+		}
 	}
 }
 

--- a/src/window_tracker.h
+++ b/src/window_tracker.h
@@ -72,7 +72,8 @@ void sc_update_tracked_bounds(TrackedWindowList *list);
 //   2. 0.15초 미만이면 즉시 리턴 (대부분의 호출은 여기서 끝)
 //   3. 임계 도달 시 sc_scan_blacklisted_windows 1회 + *out 업데이트 + obs_log 출력
 //   4. *accumulator = 0
-void sc_tracker_tick(float seconds, float *accumulator, TrackedWindowList *out);
+// interval: 실제 스캔 주기(초). 기본 0.15초, 게임 모드 시 0.5초 전달.
+void sc_tracker_tick(float seconds, float *accumulator, TrackedWindowList *out, float interval);
 
 #ifdef __cplusplus
 }

--- a/src/window_tracker.h
+++ b/src/window_tracker.h
@@ -54,19 +54,25 @@ struct TrackedWindowList {
 // (DwmGetWindowAttribute는 caller 스레드 컨텍스트로 동작).
 void sc_scan_blacklisted_windows(TrackedWindowList *out);
 
+// Fast-path 좌표 갱신: 이미 list에 들어있는 HWND들에 대해 DWM으로 bounds만 재조회.
+// EnumWindows / OpenProcess 없이 DWM query만 수행하므로 매 프레임 호출 가능.
+//
+// 창이 닫혀 IsWindowVisible이 false가 되면 해당 슬롯을 list에서 즉시 제거한다.
+// (slow scan은 새 창 발견용, fast-path는 이미 알고 있는 창의 위치 추적용)
+void sc_update_tracked_bounds(TrackedWindowList *list);
+
 // video_tick의 throttle 헬퍼.
-// seconds : 직전 tick과의 경과 시간 (60fps면 약 0.0167)
+// seconds     : 직전 tick과의 경과 시간 (60fps면 약 0.0167)
 // accumulator : 누산값 보관 위치 (보통 SecureCastFilter::trackerAccumulator)
+// out         : 스캔이 실행된 경우에만 결과로 채워짐; throttle로 스킵되면 불변.
+//               null 허용 (결과가 필요 없으면 null 전달).
 //
 // 동작:
 //   1. *accumulator += seconds
 //   2. 0.15초 미만이면 즉시 리턴 (대부분의 호출은 여기서 끝)
-//   3. 임계 도달 시 sc_scan_blacklisted_windows 1회 + 결과를 obs_log로 출력
+//   3. 임계 도달 시 sc_scan_blacklisted_windows 1회 + *out 업데이트 + obs_log 출력
 //   4. *accumulator = 0
-//
-// 0.15초인 이유: 사람이 창 이동 후 마우스를 떼는 데 걸리는 시간보다 짧으면서,
-// 60fps tick 매번(0.0167) 호출하는 것보다는 ~9배 적게 EnumWindows 호출.
-void sc_tracker_tick(float seconds, float *accumulator);
+void sc_tracker_tick(float seconds, float *accumulator, TrackedWindowList *out);
 
 #ifdef __cplusplus
 }

--- a/src/window_tracker.h
+++ b/src/window_tracker.h
@@ -69,7 +69,7 @@ void sc_update_tracked_bounds(TrackedWindowList *list);
 //
 // 동작:
 //   1. *accumulator += seconds
-//   2. 0.15초 미만이면 즉시 리턴 (대부분의 호출은 여기서 끝)
+//   2. interval 미만이면 즉시 리턴 (대부분의 호출은 여기서 끝)
 //   3. 임계 도달 시 sc_scan_blacklisted_windows 1회 + *out 업데이트 + obs_log 출력
 //   4. *accumulator = 0
 // interval: 실제 스캔 주기(초). 기본 0.15초, 게임 모드 시 0.5초 전달.


### PR DESCRIPTION
## 📌 어떤 작업에 대한 PR인가요?
- HLSL 블러 셰이더 추가 (WinEventListener 초기 구현)

- 마스킹 정확도 개선
: lingering rect, N+N-1 합집합, 캡처 레이턴시 보정

- alt + tab / task view / 뒤로 보내기 전환 시 감지 및 마스킹 지연 개선
: 창 전환 UI 예외 처리, FOREGROUND 훅 추가

- 앱 복원 시 첫 프레임부터 마스킹
- 탐지 전 백로그 프레임 노출 수정
- 복원 직후 강제 스캔 race condition 수정

- 패닉버튼
: Ctrl + shift + F12 전체 블랙아웃, 빨간 테두리 인디케이터

- CPU 고소모율 (게임 등) 감지 
: CPU >= 40% 3초일때 진입 - CPU <= 30% 5초일때 이탈

Closes #10 